### PR TITLE
Add Missing Meta File

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  author: Ona Engineering
+  description: Installs OpenJDK
+  company: Ona Systems Inc.
+  license: Apache 2
+  min_ansible_version: 2.2
+  platforms:
+    - name: Ubuntu
+      verions:
+      - xenial
+  categories:
+  - OpenJDK
+  - Java
+
+dependencies: []


### PR DESCRIPTION
Solves an issue where importing role using ansible-galaxy fails due to missing meta/main.yml file
